### PR TITLE
chore: duplicate assets to static

### DIFF
--- a/website/static/context/aatp-dlp-context-0.3.2.jsonld
+++ b/website/static/context/aatp-dlp-context-0.3.2.jsonld
@@ -1,0 +1,452 @@
+{
+  "@context": {
+    "aatp-dlp": "https://vocabulary.aatp.org/aatp/dlp0",
+    "untp-core": "https://vocabulary.uncefact.org/untp/core/0/",
+    "aatp-core": "https://vocabulary.agtrace.com.au/aatp/core/0",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "@protected": true,
+    "@version": 1.1,
+    "IdentifierScheme": {
+      "@protected": true,
+      "@id": "untp-core:IdentifierScheme",
+      "@context": {}
+    },
+    "Entity": {
+      "@protected": true,
+      "@id": "untp-core:Entity",
+      "@context": {
+        "registeredId": {
+          "@id": "untp-core:registeredId",
+          "@type": "xsd:string"
+        },
+        "idScheme": {
+          "@id": "aatp-dlp:idScheme",
+          "@type": "@id"
+        }
+      }
+    },
+    "CredentialIssuer": {
+      "@protected": true,
+      "@id": "untp-core:CredentialIssuer",
+      "@context": {
+        "otherIdentifiers": {
+          "@id": "aatp-dlp:otherIdentifiers",
+          "@type": "@id"
+        }
+      }
+    },
+    "BovineDeclaration": {
+      "@protected": true,
+      "@id": "aatp-dlp:BovineDeclaration",
+      "@context": {
+        "referenceStandard": "untp-core:referenceStandard",
+        "referenceRegulation": "untp-core:referenceRegulation",
+        "assessmentCriteria": "untp-core:assessmentCriteria",
+        "declaredValues": "untp-core:declaredValues",
+        "compliance": "untp-core:compliance",
+        "conformityTopic": "untp-core:conformityTopic"
+      }
+    },
+    "BovineAnimal": {
+      "@protected": true,
+      "@id": "aatp-dlp:BovineAnimal",
+      "@context": {
+        "name": "untp-core:name",
+        "registeredId": "untp-core:registeredId",
+        "idScheme": "untp-core:idScheme",
+        "nlisId": "untp-core:serialNumber",
+        "mobNumber": "untp-core:batchNumber",
+        "productImage": "untp-core:productImage",
+        "description": "untp-core:description",
+        "productCategory": "untp-core:productCategory",
+        "furtherInformation": "untp-core:furtherInformation",
+        "producedByParty": "untp-core:producedByParty",
+        "producedAtFacility": "untp-core:producedAtFacility",
+        "countryOfProduction": "untp-core:countryOfProduction",
+        "dimensions": "untp-core:dimensions",
+        "birthDate": "untp-core:productionDate",
+        "characteristics": "aatp-core:characteristics",
+        "healthTreatments": "aatp-core:healthTreatments",
+        "emissionsScorecard": "untp-core:emissionsScorecard",
+        "conformityDeclarations": {
+          "@id": "aatp-dlp:conformityDeclarations",
+          "@type": "@id"
+        }
+      }
+    },
+    "DigitalLivestockPassport": {
+      "@protected": true,
+      "@id": "aatp-dlp:DigitalLivestockPassport",
+      "@context": {
+        "issuer": {
+          "@id": "aatp-dlp:issuer",
+          "@type": "@id"
+        },
+        "validFrom": {
+          "@id": "aatp-dlp:validFrom",
+          "@type": "xsd:string"
+        },
+        "validUntil": {
+          "@id": "aatp-dlp:validUntil",
+          "@type": "xsd:string"
+        },
+        "credentialSubject": {
+          "@id": "aatp-dlp:credentialSubject",
+          "@type": "@id"
+        }
+      }
+    },
+    "Animal": {
+      "@protected": true,
+      "@id": "aatp-core:Animal",
+      "@context": {
+        "name": "untp-core:name",
+        "registeredId": "untp-core:registeredId",
+        "idScheme": "untp-core:idScheme",
+        "nlisId": "untp-core:serialNumber",
+        "mobNumber": "untp-core:batchNumber",
+        "productImage": "untp-core:productImage",
+        "description": "untp-core:description",
+        "productCategory": "untp-core:productCategory",
+        "furtherInformation": "untp-core:furtherInformation",
+        "producedByParty": "untp-core:producedByParty",
+        "producedAtFacility": "untp-core:producedAtFacility",
+        "countryOfProduction": "untp-core:countryOfProduction",
+        "dimensions": "untp-core:dimensions",
+        "birthDate": "untp-core:productionDate"
+      }
+    },
+    "Classification": {
+      "@protected": true,
+      "@id": "untp-core:Classification",
+      "@context": {
+        "code": {
+          "@id": "untp-core:code",
+          "@type": "xsd:string"
+        },
+        "schemeID": {
+          "@id": "untp-core:schemeID",
+          "@type": "xsd:string"
+        },
+        "schemeName": {
+          "@id": "untp-core:schemeName",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "Product": {
+      "@protected": true,
+      "@id": "untp-core:Product",
+      "@context": {
+        "registeredId": {
+          "@id": "untp-core:registeredId",
+          "@type": "xsd:string"
+        },
+        "idScheme": {
+          "@id": "aatp-dlp:idScheme",
+          "@type": "@id"
+        },
+        "serialNumber": {
+          "@id": "untp-core:serialNumber",
+          "@type": "xsd:string"
+        },
+        "batchNumber": {
+          "@id": "untp-core:batchNumber",
+          "@type": "xsd:string"
+        },
+        "productImage": {
+          "@protected": true,
+          "@id": "untp-core:productImage",
+          "@context": {
+            "linkURL": {
+              "@id": "untp-core:linkURL",
+              "@type": "xsd:string"
+            },
+            "linkName": {
+              "@id": "untp-core:linkName",
+              "@type": "xsd:string"
+            },
+            "linkType": {
+              "@id": "untp-core:linkType",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "productCategory": {
+          "@id": "aatp-dlp:productCategory",
+          "@type": "@id"
+        },
+        "furtherInformation": {
+          "@protected": true,
+          "@id": "untp-core:furtherInformation",
+          "@context": {
+            "linkURL": {
+              "@id": "untp-core:linkURL",
+              "@type": "xsd:string"
+            },
+            "linkName": {
+              "@id": "untp-core:linkName",
+              "@type": "xsd:string"
+            },
+            "linkType": {
+              "@id": "untp-core:linkType",
+              "@type": "xsd:string"
+            }
+          }
+        },
+        "producedByParty": {
+          "@id": "aatp-dlp:producedByParty",
+          "@type": "@id"
+        },
+        "producedAtFacility": {
+          "@id": "aatp-dlp:producedAtFacility",
+          "@type": "@id"
+        },
+        "dimensions": {
+          "@protected": true,
+          "@id": "untp-core:dimensions",
+          "@context": {
+            "weight": {
+              "@protected": true,
+              "@id": "untp-core:weight",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "length": {
+              "@protected": true,
+              "@id": "untp-core:length",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "width": {
+              "@protected": true,
+              "@id": "untp-core:width",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "height": {
+              "@protected": true,
+              "@id": "untp-core:height",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "volume": {
+              "@protected": true,
+              "@id": "untp-core:volume",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "productionDate": {
+          "@id": "untp-core:productionDate",
+          "@type": "xsd:string"
+        },
+        "countryOfProduction": {
+          "@id": "untp-core:countryOfProduction",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "@vocab": "https://vocabulary.uncefact.org/CountryId"
+          }
+        }
+      }
+    },
+    "Standard": {
+      "@protected": true,
+      "@id": "untp-core:Standard",
+      "@context": {
+        "issuingParty": {
+          "@id": "aatp-dlp:issuingParty",
+          "@type": "@id"
+        },
+        "issueDate": {
+          "@id": "untp-core:issueDate",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "Regulation": {
+      "@protected": true,
+      "@id": "untp-core:Regulation",
+      "@context": {
+        "jurisdictionCountry": {
+          "@id": "untp-core:jurisdictionCountry",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "@vocab": "https://vocabulary.uncefact.org/CountryId"
+          }
+        },
+        "administeredBy": {
+          "@id": "aatp-dlp:administeredBy",
+          "@type": "@id"
+        },
+        "effectiveDate": {
+          "@id": "untp-core:effectiveDate",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "Criterion": {
+      "@protected": true,
+      "@id": "untp-core:Criterion",
+      "@context": {
+        "thresholdValues": {
+          "@protected": true,
+          "@id": "untp-core:thresholdValues",
+          "@context": {
+            "metricName": {
+              "@id": "untp-core:metricName",
+              "@type": "xsd:string"
+            },
+            "metricValue": {
+              "@protected": true,
+              "@id": "untp-core:metricValue",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "accuracy": {
+              "@id": "untp-core:accuracy",
+              "@type": "xsd:decimal"
+            }
+          }
+        }
+      }
+    },
+    "Declaration": {
+      "@protected": true,
+      "@id": "untp-core:Declaration",
+      "@context": {
+        "referenceStandard": {
+          "@id": "aatp-dlp:referenceStandard",
+          "@type": "@id"
+        },
+        "referenceRegulation": {
+          "@id": "aatp-dlp:referenceRegulation",
+          "@type": "@id"
+        },
+        "assessmentCriteria": {
+          "@id": "aatp-dlp:assessmentCriteria",
+          "@type": "@id"
+        },
+        "declaredValues": {
+          "@protected": true,
+          "@id": "untp-core:declaredValues",
+          "@context": {
+            "metricName": {
+              "@id": "untp-core:metricName",
+              "@type": "xsd:string"
+            },
+            "metricValue": {
+              "@protected": true,
+              "@id": "untp-core:metricValue",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "accuracy": {
+              "@id": "untp-core:accuracy",
+              "@type": "xsd:decimal"
+            }
+          }
+        },
+        "compliance": {
+          "@id": "untp-core:compliance",
+          "@type": "xsd:boolean"
+        },
+        "conformityTopic": {
+          "@id": "untp-core:conformityTopic",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "@vocab": "https://vocabulary.uncefact.org/untp/core/0/conformityTopicCode#"
+          }
+        }
+      }
+    }
+  }
+}

--- a/website/static/context/aatp-dlp-context-0.4.0.jsonld
+++ b/website/static/context/aatp-dlp-context-0.4.0.jsonld
@@ -1,0 +1,345 @@
+{
+  "@context": {
+    "aatp-dlp": "https://vocabulary.aatp.org/aatp/dlp0",
+    "untp-core": "https://vocabulary.uncefact.org/untp/core/0/",
+    "untp-dpp": "https://vocabulary.uncefact.org/untp/dpp/0/",
+    "aatp-core": "https://vocabulary.agtrace.com.au/aatp/core/0",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "@protected": true,
+    "@version": 1.1,
+    "BovineAnimal": {
+      "@protected": true,
+      "@id": "aatp-dlp:BovineAnimal",
+      "@context": {
+        "countryOfProduction": "untp-core:countryOfProduction",
+        "registeredId": "untp-dpp:registeredId",
+        "idScheme": "untp-dpp:idScheme",
+        "batchNumber": "untp-dpp:batchNumber",
+        "productImage": "untp-dpp:productImage",
+        "productCategory": "untp-dpp:productCategory",
+        "furtherInformation": "untp-dpp:furtherInformation",
+        "producedByParty": {
+          "@id": "aatp-dlp:producedByParty",
+          "@type": "gs1:manufacturer"
+        },
+        "producedAtFacility": "untp-dpp:producedAtFacility",
+        "productionDate": "untp-dpp:productionDate",
+        "granularityLevel": "untp-dpp:granularityLevel",
+        "conformityClaim": "untp-dpp:conformityClaim",
+        "emissionsScorecard": "untp-dpp:emissionsScorecard",
+        "traceabilityInformation": "untp-dpp:traceabilityInformation",
+        "characteristics": "aatp-core:characteristics",
+        "healthTreatment": "aatp-core:healthTreatment"
+      }
+    },
+    "DigitalLivestockPassport": {
+      "@protected": true,
+      "@id": "aatp-dlp:DigitalLivestockPassport",
+      "@context": {
+        "credentialSubject": {
+          "@id": "aatp-dlp:credentialSubject",
+          "@type": "@id"
+        }
+      }
+    },
+    "IdentifierScheme": {
+      "@protected": true,
+      "@id": "untp-core:IdentifierScheme"
+    },
+    "Identifier": {
+      "@protected": true,
+      "@id": "untp-core:Identifier",
+      "@context": {
+        "registeredId": {
+          "@id": "untp-core:registeredId",
+          "@type": "xsd:string"
+        },
+        "idScheme": {
+          "@id": "untp-core:idScheme",
+          "@type": "@id"
+        }
+      }
+    },
+    "CredentialIssuer": {
+      "@protected": true,
+      "@id": "untp-core:CredentialIssuer",
+      "@context": {
+        "otherIdentifier": {
+          "@id": "untp-core:otherIdentifier",
+          "@type": "@id"
+        }
+      }
+    },
+    "Claim": {
+      "@protected": true,
+      "@id": "untp-dpp:Claim",
+      "@context": {
+        "assessmentDate": {
+          "@id": "untp-dpp:assessmentDate",
+          "@type": "xsd:string"
+        },
+        "declaredValue": {
+          "@protected": true,
+          "@id": "untp-core:declaredValue",
+          "@context": {
+            "metricName": {
+              "@id": "untp-core:metricName",
+              "@type": "xsd:string"
+            },
+            "metricValue": {
+              "@protected": true,
+              "@id": "untp-core:metricValue",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "score": {
+              "@id": "untp-core:score",
+              "@type": "xsd:string"
+            },
+            "accuracy": {
+              "@id": "untp-core:accuracy",
+              "@type": "xsd:decimal"
+            }
+          }
+        },
+        "referenceStandard": "untp-core:referenceStandard",
+        "referenceRegulation": "untp-core:referenceRegulation",
+        "assessmentCriteria": "untp-core:assessmentCriteria",
+        "declaredValues": "untp-core:declaredValue",
+        "conformance": "untp-core:conformance",
+        "conformityTopic": "untp-core:conformityTopic",
+        "conformityEvidence": "untp-core:conformityEvidence"
+      }
+    },
+    "Product": {
+      "@protected": true,
+      "@id": "untp-core:Product",
+      "@context": {
+        "registeredId": "untp-core:registeredId",
+        "idScheme": "untp-core:idScheme",
+        "serialNumber": "untp-core:serialNumber",
+        "batchNumber": "untp-core:batchNumber",
+        "productImage": "untp-core:productImage",
+        "productCategory": "untp-core:productCategory",
+        "furtherInformation": "untp-core:furtherInformation",
+        "producedByParty": {
+          "@id": "aatp-dlp:producedByParty",
+          "@type": "gs1:manufacturer"
+        },
+        "producedAtFacility": "untp-core:producedAtFacility",
+        "dimensions": "untp-core:dimensions",
+        "productionDate": "untp-core:productionDate",
+        "countryOfProduction": "untp-core:countryOfProduction",
+        "granularityLevel": {
+          "@id": "untp-dpp:granularityLevel",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "@vocab": "https://vocabulary.uncefact.org/untp/dpp/0/granularityCode#"
+          }
+        },
+        "dueDiligenceDeclaration": "untp-core:dueDiligenceDeclaration",
+        "materialsProvenance": "untp-core:materialsProvenance",
+        "conformityClaim": {
+          "@id": "untp-dpp:conformityClaim",
+          "@type": "@id"
+        },
+        "circularityScorecard": "untp-core:circularityScorecard",
+        "emissionsScorecard": "untp-core:emissionsScorecard",
+        "traceabilityInformation": {
+          "@protected": true,
+          "@id": "untp-dpp:traceabilityInformation",
+          "@context": {
+            "valueChainProcess": {
+              "@id": "untp-dpp:valueChainProcess",
+              "@type": "xsd:string"
+            },
+            "verifiedRatio": {
+              "@id": "untp-dpp:verifiedRatio",
+              "@type": "xsd:decimal"
+            },
+            "traceabilityEvent": "untp-core:traceabilityEvent"
+          }
+        }
+      }
+    },
+    "Classification": {
+      "@protected": true,
+      "@id": "untp-core:Classification",
+      "@context": {
+        "code": {
+          "@id": "untp-core:code",
+          "@type": "xsd:string"
+        },
+        "schemeID": {
+          "@id": "untp-core:schemeID",
+          "@type": "xsd:string"
+        },
+        "schemeName": {
+          "@id": "untp-core:schemeName",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "Standard": {
+      "@protected": true,
+      "@id": "untp-core:Standard",
+      "@context": {
+        "issuingParty": {
+          "@id": "untp-core:issuingParty",
+          "@type": "@id"
+        },
+        "issueDate": {
+          "@id": "untp-core:issueDate",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "Regulation": {
+      "@protected": true,
+      "@id": "untp-core:Regulation",
+      "@context": {
+        "jurisdictionCountry": {
+          "@id": "untp-core:jurisdictionCountry",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "@vocab": "https://vocabulary.uncefact.org/CountryId"
+          }
+        },
+        "administeredBy": {
+          "@id": "untp-core:administeredBy",
+          "@type": "@id"
+        },
+        "effectiveDate": {
+          "@id": "untp-core:effectiveDate",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "Criterion": {
+      "@protected": true,
+      "@id": "untp-core:Criterion",
+      "@context": {
+        "thresholdValues": {
+          "@protected": true,
+          "@id": "untp-core:thresholdValues",
+          "@context": {
+            "metricName": {
+              "@id": "untp-core:metricName",
+              "@type": "xsd:string"
+            },
+            "metricValue": {
+              "@protected": true,
+              "@id": "untp-core:metricValue",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "score": {
+              "@id": "untp-core:score",
+              "@type": "xsd:string"
+            },
+            "accuracy": {
+              "@id": "untp-core:accuracy",
+              "@type": "xsd:decimal"
+            }
+          }
+        }
+      }
+    },
+    "Declaration": {
+      "@protected": true,
+      "@id": "untp-core:Declaration",
+      "@context": {
+        "referenceStandard": {
+          "@id": "untp-core:referenceStandard",
+          "@type": "@id"
+        },
+        "referenceRegulation": {
+          "@id": "untp-core:referenceRegulation",
+          "@type": "@id"
+        },
+        "assessmentCriteria": {
+          "@id": "untp-core:assessmentCriteria",
+          "@type": "@id"
+        },
+        "assessmentDate": {
+          "@id": "untp-core:assessmentDate",
+          "@type": "xsd:string"
+        },
+        "declaredValue": {
+          "@protected": true,
+          "@id": "untp-core:declaredValue",
+          "@context": {
+            "metricName": {
+              "@id": "untp-core:metricName",
+              "@type": "xsd:string"
+            },
+            "metricValue": {
+              "@protected": true,
+              "@id": "untp-core:metricValue",
+              "@context": {
+                "value": {
+                  "@id": "untp-core:value",
+                  "@type": "xsd:decimal"
+                },
+                "unit": {
+                  "@id": "untp-core:unit",
+                  "@type": "@vocab",
+                  "@context": {
+                    "@protected": true,
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                  }
+                }
+              }
+            },
+            "score": {
+              "@id": "untp-core:score",
+              "@type": "xsd:string"
+            },
+            "accuracy": {
+              "@id": "untp-core:accuracy",
+              "@type": "xsd:decimal"
+            }
+          }
+        },
+        "conformance": {
+          "@id": "untp-core:conformance",
+          "@type": "xsd:boolean"
+        },
+        "conformityTopic": {
+          "@id": "untp-core:conformityTopic",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "@vocab": "https://vocabulary.uncefact.org/untp/core/0/conformityTopicCode#"
+          }
+        }
+      }
+    }
+  }
+}

--- a/website/static/schema/aatp-dlp-schema-0.3.2.json
+++ b/website/static/schema/aatp-dlp-schema-0.3.2.json
@@ -1,0 +1,888 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "array",
+      "readOnly": true,
+      "const": ["DigitalLivestockPassport", "VerifiableCredential"],
+      "default": ["DigitalLivestockPassport", "VerifiableCredential"],
+      "items": {
+        "type": "string",
+        "enum": ["DigitalLivestockPassport", "VerifiableCredential"]
+      }
+    },
+    "@context": {
+      "example": "https://test.uncefact.org/vocabulary/untp/dpp/dpp-context.jsonld",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://vocabulary.aatp.org/aatp/dlp0.3.2"
+        ]
+      },
+      "description": "A list of JSON-LD context URIs that define the seamntic meaning of prperties within the credential. ",
+      "readOnly": true,
+      "const": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://vocabulary.aatp.org/aatp/dlp0.3.2"
+      ],
+      "default": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://vocabulary.aatp.org/aatp/dlp0.3.2"
+      ]
+    },
+    "id": {
+      "example": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
+      "type": "string",
+      "format": "uri",
+      "description": "A unique identifier (URI) assigned to the product passport. May be a UUID"
+    },
+    "issuer": {
+      "$ref": "#/$defs/CredentialIssuer",
+      "description": "The organisation that is the isuer of this VC. Note that the \"id\" property MUST be a W3C DID.  Other identifiers such as tax registration numbers can be listed in the \"otherIdentifiers\" property."
+    },
+    "validFrom": {
+      "example": "2024-03-15",
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time from which the credential is valid."
+    },
+    "validUntil": {
+      "example": "2034-03-15",
+      "type": "string",
+      "format": "date-time",
+      "description": "The expiry date (if applicable) of this verifiable credential."
+    },
+    "credentialSubject": {
+      "$ref": "#/$defs/BovineAnimal",
+      "description": "The animal record that is the subject of this digital livestock passport. "
+    }
+  },
+  "description": "A digital livestock passport. ",
+  "required": ["@context", "id", "issuer"],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "CredentialIssuer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "default": "CredentialIssuer",
+          "enum": ["CredentialIssuer"]
+        },
+        "id": {
+          "example": "did:web:identifiers.example-company.com:12345",
+          "type": "string",
+          "format": "uri",
+          "description": "The W3C DID of the issuer - should be a did:web or did:tdw"
+        },
+        "name": {
+          "example": "Example Company Pty Ltd",
+          "type": "string",
+          "description": "The name of the issuer person or organisation"
+        },
+        "otherIdentifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Entity"
+          },
+          "description": "An optional list of other registered identifiers for this credential issuer "
+        }
+      },
+      "description": "The issuer party ()person or orgnaition) of a verifiable credential.",
+      "required": ["id", "name"]
+    },
+    "Entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "default": "Entity",
+          "enum": ["Entity"]
+        },
+        "id": {
+          "example": "https://id.gs1.org/01/09520123456788/21/12345",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique ID of the entity as a resolvable URL according to ISO 18975. ExamplesProduct - id.gs1.org/01/09520123456788/21/12345  Party - abr.business.gov.au/ABN/View?abn=90664869327. Facility - did:web:facilities.example-company.com:123. "
+        },
+        "name": {
+          "example": "EV battery 300Ah.",
+          "type": "string",
+          "description": "The registered name of the entity within the identifier scheme.  Examplesproduct - EV battery 300Ahparty - Sample Company Pty Ltd. facility - Greenacres battery factory"
+        },
+        "registeredId": {
+          "example": "90664869327",
+          "type": "string",
+          "description": "The registration number (alphanumeric) of the entity within the register. Unique within the register."
+        },
+        "idScheme": {
+          "$ref": "#/$defs/IdentifierScheme",
+          "description": "The identifier scheme.  Exampleproduct - id.gs1.org/01. party - business.gov.au/abn  facility - did:web:facilities.acme.com. "
+        }
+      },
+      "description": "The ID and Name of an identified entity such qs a product, facility, party, standard, etc.  If the identifier is a W3C DID then the corresponding DID document SHOULD include a serviceEndpoint of type \"IdentityResolver\". If the identifier is not a W3C DID then the id peroperty SHOULD be an identity resolver URL.",
+      "required": ["id", "name"]
+    },
+    "IdentifierScheme": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "default": "IdentifierScheme",
+          "enum": ["IdentifierScheme"]
+        },
+        "id": {
+          "example": "https://id.gs1.org/01/",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique identifier of the registration scheme. The scheme should be registered and discoverable from vocabulary.uncefact.org/identifierSchemes"
+        },
+        "name": {
+          "example": "Global Trade Identification Number (GTIN)",
+          "type": "string",
+          "description": "The name of the identifier scheme. "
+        }
+      },
+      "description": "An identifier registration scheme for products, facilities, or organisations. Typically operated by a state, national or gloabl authority."
+    },
+    "BovineAnimal": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["BovineAnimal", "Animal", "Product", "Entity"],
+          "default": ["BovineAnimal", "Animal", "Product", "Entity"],
+          "items": {
+            "type": "string",
+            "enum": ["BovineAnimal", "Animal", "Product", "Entity"]
+          }
+        },
+        "name": {
+          "example": "EV battery 300Ah.",
+          "type": "string",
+          "description": "The registered name of the entity within the identifier scheme.  Examplesproduct - EV battery 300Ahparty - Sample Company Pty Ltd. facility - Greenacres battery factory"
+        },
+        "registeredId": {
+          "example": "90664869327",
+          "type": "string",
+          "description": "The registration number (alphanumeric) of the entity within the register. Unique within the register."
+        },
+        "idScheme": {
+          "$ref": "#/$defs/IdentifierScheme",
+          "description": "The identifier scheme.  Exampleproduct - id.gs1.org/01. party - business.gov.au/abn  facility - did:web:facilities.acme.com. "
+        },
+        "nlisId": {
+          "example": "12345678",
+          "type": "string",
+          "description": "The NLIS identifier of the animal"
+        },
+        "mobNumber": {
+          "example": "6789",
+          "type": "string",
+          "description": "The identifier of the herd or mob of which this animal is a member.  "
+        },
+        "productImage": {
+          "$ref": "#/$defs/Link",
+          "description": "Reference information (location, type, name) of an image of the product."
+        },
+        "description": {
+          "example": "400Ah 24v LiFePO4 battery",
+          "type": "string",
+          "description": "A textual description providing details about the product."
+        },
+        "productCategory": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": "A code representing the product's class, typically using the UN CPC (United Nations Central Product Classification) https://unstats.un.org/unsd/classifications/Econ/cpc"
+        },
+        "furtherInformation": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Link"
+          },
+          "description": "A URL pointing to further human readable information about the product."
+        },
+        "producedByParty": {
+          "$ref": "#/$defs/Entity",
+          "description": "The Party entity that manufactured the product."
+        },
+        "producedAtFacility": {
+          "$ref": "#/$defs/Entity",
+          "description": "The Facility where the product batch was produced / manufactured."
+        },
+        "countryOfProduction": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId",
+          "description": "The country in which this item was produced / manufactured.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId\n    "
+        },
+        "dimensions": {
+          "$ref": "#/$defs/Dimension",
+          "description": "The physical dimensions of the product. Not every dimension is relevant to every products.  For example bulk materials may have wieght and volume but not length, with, or height.\"weight\":{\"value\":10, \"unit\":\"KGM\"}"
+        },
+        "birthDate": {
+          "example": "2021-02-15",
+          "type": "string",
+          "format": "date",
+          "description": "The birth date of the animal.  May be set to the onset of calving period (as an idicator or maximum age).  "
+        },
+        "id": {
+          "example": "https://resolver.nlis.com.au/nlis/na477352xbr01234",
+          "type": "string",
+          "format": "uri",
+          "description": "The National Livestock Idenficiation System (NLIS) ID  expressed as a URI as follows https://{resolver}.{issuerDomain}/nlis/{Identifier}.  The idenfiier may be either the structured NLIS ID or the RFID tag ID. "
+        },
+        "characteristics": {
+          "$ref": "#/$defs/BovineCharcteristics",
+          "description": "The bovine characteristics for this animal in acordance with MLA guidelines https://www.ausmeat.com.au/media/1521/mla-national-livestock-guidelines-2022-web_final_291122.pdf. "
+        },
+        "healthTreatments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HealthTreatment"
+          },
+          "description": "The health treatment history for this animal in accordance with APMVA guidelines https://www.apvma.gov.au/"
+        },
+        "emissionsScorecard": {
+          "$ref": "#/$defs/EmissionsPerformance",
+          "description": "The emissions scorecard for this animal in accordance witht he GHG protocol"
+        },
+        "conformityDeclarations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/BovineDeclaration"
+          },
+          "description": "A list of conformity declarations for this animal against specific criteria from a standard or regulation."
+        }
+      },
+      "description": "A bovine animal record.  ",
+      "required": ["name", "id"]
+    },
+    "Link": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "linkURL": {
+          "example": "https://files.example-certifier.com/1234567.json",
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the target resource. "
+        },
+        "linkName": {
+          "example": "GBA rule book conformity certificate",
+          "type": "string",
+          "description": "A display name for the target resource "
+        },
+        "linkType": {
+          "example": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
+          "type": "string",
+          "description": "The type of the target resource - drawn from a controlled vocabulary "
+        }
+      },
+      "description": "A structure to provide a URL link plus metadata associated with the link."
+    },
+    "Classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "default": "Classification",
+          "enum": ["Classification"]
+        },
+        "id": {
+          "example": "https://unstats.un.org/unsd/classifications/Econ/cpc/46410",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique URI representing the specific classifier value"
+        },
+        "code": {
+          "example": "46410",
+          "type": "string",
+          "description": "classification code within the scheme"
+        },
+        "name": {
+          "example": "Primary cells and primary batteries",
+          "type": "string",
+          "description": "Name of the classification represented by the code"
+        },
+        "schemeID": {
+          "example": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+          "type": "string",
+          "format": "uri",
+          "description": "Classification scheme ID"
+        },
+        "schemeName": {
+          "example": "UN Central Product Classification (CPC)",
+          "type": "string",
+          "description": "The name of the classification scheme"
+        }
+      },
+      "description": "A classification scheme and code / name representing a category value for a product, entity, or facility.",
+      "required": ["id", "name"]
+    },
+    "Dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "weight": {
+          "$ref": "#/$defs/Measure",
+          "description": "the weight of the product. EG {\"value\":10, \"unit\":\"KGM\"}"
+        },
+        "length": {
+          "$ref": "#/$defs/Measure",
+          "description": "The length of the product or packaging eg {\"value\":840, \"unit\":\"MMT\"}"
+        },
+        "width": {
+          "$ref": "#/$defs/Measure",
+          "description": "The width of the product or packaging. eg {\"value\":150, \"unit\":\"MMT\"}"
+        },
+        "height": {
+          "$ref": "#/$defs/Measure",
+          "description": "The height of the product or packaging. eg {\"value\":220, \"unit\":\"MMT\"}"
+        },
+        "volume": {
+          "$ref": "#/$defs/Measure",
+          "description": "The displacement volume of the product. eg {\"value\":7.5, \"unit\":\"LTR\"}"
+        }
+      },
+      "description": "Overall (length, width, height) dimensions and weight/volume of an item."
+    },
+    "Measure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "example": 10,
+          "type": "number",
+          "description": "The numeric value of the measure"
+        },
+        "unit": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/UnitMeasureCode",
+          "description": "Unit of measure drawn from the UNECE rec20 measure code list.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/UnitMeasureCode\n    "
+        }
+      },
+      "description": "The measure class defines a numeric measured value (eg 10) and a coded unit of measure (eg KG).",
+      "required": ["value", "unit"]
+    },
+    "BovineCharcteristics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["BovineCharcteristics", "Characteristic"],
+          "default": ["BovineCharcteristics", "Characteristic"],
+          "items": {
+            "type": "string",
+            "enum": ["BovineCharcteristics", "Characteristic"]
+          }
+        },
+        "sex": {
+          "type": "string",
+          "enum": ["M", "F"],
+          "example": "M",
+          "description": "The sex of the animal."
+        },
+        "sexCharacteristic": {
+          "type": "string",
+          "enum": [
+            "HY ",
+            "C ",
+            "CSP ",
+            "HC ",
+            "H ",
+            "HSP ",
+            "BY ",
+            "SC",
+            "S",
+            "V ",
+            "MFV ",
+            "BC",
+            "B",
+            "SY",
+            "RV"
+          ],
+          "example": "HY ",
+          "description": "Characteristic based on sex and age. Eg HY for yearling heiffer"
+        },
+        "breed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "enum": [
+            "AA",
+            "AB",
+            "AF",
+            "AK",
+            "AL",
+            "AN",
+            "AU",
+            "AY",
+            "BA",
+            "BB",
+            "BC",
+            "BE",
+            "BF",
+            "BG",
+            "BH",
+            "BJ",
+            "BK",
+            "BL",
+            "BM",
+            "BN",
+            "BO",
+            "BQ",
+            "BR",
+            "BU",
+            "BV",
+            "BW",
+            "BY",
+            "BZ",
+            "CA",
+            "CB",
+            "CC",
+            "CD",
+            "CF",
+            "CI",
+            "CN",
+            "DD",
+            "DK",
+            "DM",
+            "DR",
+            "DS",
+            "DX",
+            "FF",
+            "FS",
+            "GA",
+            "GC",
+            "GG",
+            "GM",
+            "GV",
+            "HH",
+            "HI",
+            "HU",
+            "HV",
+            "IB",
+            "IS",
+            "JJ",
+            "KA",
+            "KW",
+            "LB",
+            "LH",
+            "LL",
+            "LR",
+            "LU",
+            "MA",
+            "MD",
+            "MG",
+            "MH",
+            "MI",
+            "MO",
+            "MS",
+            "MU",
+            "MZ",
+            "NG",
+            "NL",
+            "NO",
+            "OO",
+            "OZ",
+            "PH",
+            "PM",
+            "PR",
+            "PT",
+            "PU",
+            "PZ",
+            "QL",
+            "RA",
+            "RB",
+            "RC",
+            "RF",
+            "RO",
+            "RP",
+            "RS",
+            "RV",
+            "SA",
+            "SB",
+            "SC",
+            "SD",
+            "SE",
+            "SG",
+            "SH",
+            "SI",
+            "SK",
+            "SL",
+            "SM",
+            "SN",
+            "SP",
+            "SQ",
+            "SR",
+            "SS",
+            "ST",
+            "SU",
+            "SV",
+            "SW",
+            "TA",
+            "TC",
+            "TH",
+            "TI",
+            "TN",
+            "TP",
+            "TS",
+            "TX",
+            "UR",
+            "UU",
+            "WA",
+            "WB",
+            "WY",
+            "XA",
+            "XD",
+            "XH",
+            "XK",
+            "XM",
+            "XR",
+            "XS",
+            "XT",
+            "XX",
+            "XY",
+            "ZE"
+          ],
+          "example": "AA",
+          "description": "Breed code array.  Single code for pure bred cattle. List each breed for mixed breeds. eg [\"AA\"] represewnts pure bred Angus."
+        },
+        "liveWeight": {
+          "example": 350,
+          "type": "number",
+          "format": "float",
+          "description": "Live weight of the animal in Kg"
+        },
+        "carcassWeight": {
+          "example": 180,
+          "type": "number",
+          "format": "float",
+          "description": "Carcass weight in Kg - only applicable if passport is issued post slaughter."
+        },
+        "fatScore": {
+          "type": "string",
+          "enum": ["1", "2", "3", "4", "5", "6"],
+          "example": "1",
+          "description": "Fat score based on depth of fat at 12th to 13th rib. 1 is lightest and 6 is heaviest. "
+        },
+        "muscleScore": {
+          "type": "string",
+          "enum": ["A", "B", "C", "D", "E"],
+          "example": "A",
+          "description": "Muscle score based on thickness through stifle. A is heaviest, E is lightest."
+        },
+        "frameSize": {
+          "type": "string",
+          "enum": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
+          "example": "1",
+          "description": "Frame size (lookup based on hook height for given age and sex). 1 is the smallest and 11 is the largest."
+        },
+        "maturity": {
+          "type": "string",
+          "enum": ["early", "moderate", "late", "veryLate"],
+          "example": "early",
+          "description": "Maturity type or growth potential is a way of describingthe skeletal size of cattle. Frame score, which is the height of a beef animal at a given age can be used as a measure of its maturity type. Given adequate nutrition and health, most animals should maintain the same frame score and hence maturity type throughout their life, while actual height increases with age."
+        }
+      },
+      "description": "Bovine characteristcs at the date of livestock passport issue - terminology from MLA National Livestiock Guidelines 2022 - https://www.ausmeat.com.au/media/1521/mla-national-livestock-guidelines-2022-web_final_291122.pdf.  "
+    },
+    "HealthTreatment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "icarDiseaseCategory": {
+          "type": "string",
+          "enum": ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+          "example": "1",
+          "description": "The disease category that this treatment targets."
+        },
+        "treatmentDate": {
+          "type": "string",
+          "format": "date",
+          "description": "The data the treatment was applied."
+        },
+        "productId": {
+          "type": "string",
+          "x-external-enumeration": "https://portal.apvma.gov.au/pubcris",
+          "description": "The APVMA product code for the treatment.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://portal.apvma.gov.au/pubcris\n    "
+        },
+        "productBatchId": {
+          "type": "string",
+          "description": "The batch number of the specific treatment product."
+        },
+        "productExpiry": {
+          "type": "string",
+          "format": "date",
+          "description": "The expiry date of the specific treatemtn product batch."
+        },
+        "productName": {
+          "type": "string",
+          "description": "The name of the treatment product"
+        },
+        "doseRate": {
+          "$ref": "#/$defs/Measure",
+          "description": "The dose rate for the administered treatment."
+        },
+        "witholdingPeriod": {
+          "type": "integer",
+          "description": "The pre-slauhghter / pre export witholding period in days for this treatment.  "
+        }
+      },
+      "description": "An animal health treatment record."
+    },
+    "EmissionsPerformance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "carbonFootprint": {
+          "example": 1.8,
+          "type": "number",
+          "format": "float",
+          "description": "The carbon footprint of the product in KgCO2e per declared unit."
+        },
+        "declaredUnit": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/UnitMeasureCode",
+          "description": "The unit of product (EA, KGM, LTR, etc) that is the basis for carbon footprint.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/UnitMeasureCode\n    "
+        },
+        "operationalScope": {
+          "type": "string",
+          "enum": ["None", "CradleToGate", "CradleToGrave"],
+          "example": "None",
+          "description": "The operational scope of the emissions performance. Only scope 1 & 2, or inlcuing upstream scope 3 (cradle to gate) or upstream and downstream scope 3 (cradle to grave)."
+        },
+        "primarySourcedRatio": {
+          "example": 0.3,
+          "type": "number",
+          "format": "float",
+          "description": "The ratio of emissions data from primary sources (ie from supplier / product specific information rather than secondary / industry averages)."
+        },
+        "reportingStandard": {
+          "$ref": "#/$defs/Standard",
+          "description": "The reporting standard (eg GHG Protocol, IFRS S2, ESRS, etc) against which this product emissions performance is assessed."
+        }
+      },
+      "description": "Product specific characteristics.  This class is an extension point for industry specific product characteristics or performance information such as clothing size or battery capacity.",
+      "required": [
+        "carbonFootprint",
+        "declaredUnit",
+        "operationalScope",
+        "primarySourcedRatio"
+      ]
+    },
+    "Standard": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "default": "Standard",
+          "enum": ["Standard"]
+        },
+        "id": {
+          "example": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the standard (eg https://www.iso.org/standard/60857.html)."
+        },
+        "name": {
+          "example": "GBA Battery Passport Greenhouse Gas Rulebook - V.2.0",
+          "type": "string",
+          "description": "The name of the standard"
+        },
+        "issuingParty": {
+          "$ref": "#/$defs/Entity",
+          "description": "The party that issued the standard "
+        },
+        "issueDate": {
+          "example": "2023-12-05",
+          "type": "string",
+          "format": "date",
+          "description": "The date when the standard was issued."
+        }
+      },
+      "description": "A standard (eg ISO 14000) that specifies the criteria for conformance.",
+      "required": ["issuingParty"]
+    },
+    "BovineDeclaration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["BovineDeclaration", "Declaration"],
+          "default": ["BovineDeclaration", "Declaration"],
+          "items": {
+            "type": "string",
+            "enum": ["BovineDeclaration", "Declaration"]
+          }
+        },
+        "id": {
+          "example": "https://products.example-company.com/09520123456788/declarations/12345",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the delcaration. Often this will be an extension of the product.id or attestation.id. But could be a UUID."
+        },
+        "referenceStandard": {
+          "$ref": "#/$defs/Standard",
+          "description": "The reference to the standard that defines the specification / criteria"
+        },
+        "referenceRegulation": {
+          "$ref": "#/$defs/Regulation",
+          "description": "The reference to the regulation that defines the assessment criteria"
+        },
+        "assessmentCriteria": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Criterion"
+          },
+          "description": "The specification against which the assessment is made."
+        },
+        "declaredValues": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "The list of specific values measured as part of this assessment (eg tensile strength)"
+        },
+        "compliance": {
+          "example": "true",
+          "type": "boolean",
+          "description": "An indicator of whether or not the assessment meets the specification."
+        },
+        "conformityTopic": {
+          "type": "string",
+          "enum": [
+            "environment.energy",
+            "environment.emissions",
+            "environment.water",
+            "environment.waste",
+            "environment.deforestation",
+            "environment.biodiversity",
+            "circularity.content",
+            "circularity.design",
+            "social.labour",
+            "social.rights",
+            "social.community",
+            "social.safety",
+            "governance.ethics",
+            "governance.compliance",
+            "governance.transparency"
+          ],
+          "example": "environment.energy",
+          "description": "The conformity topic category for this assessment (eg vocabulary.uncefact.org/sustainability/emissions)"
+        }
+      },
+      "description": "A specific assessment about the product or facility against a specific specification.  Eg the carbon intensity of a given product or batch.",
+      "required": ["id", "compliance", "conformityTopic"]
+    },
+    "Regulation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "default": "Regulation",
+          "enum": ["Regulation"]
+        },
+        "id": {
+          "example": "https://www.legislation.gov.au/F2008L02309/latest/versions",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique identifier of this regulation. "
+        },
+        "name": {
+          "example": "NNational Greenhouse and Energy Reporting (Measurement) Determination",
+          "type": "string",
+          "description": "The name of the regulation or act."
+        },
+        "jurisdictionCountry": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId",
+          "description": "The legal jurisdiction (country) under which the regulation is issued.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId\n    "
+        },
+        "administeredBy": {
+          "$ref": "#/$defs/Entity",
+          "description": "the issuing body of the regulation. For example Australin Goernment Department of Climate Change, Energy, the Environment and Water"
+        },
+        "effectiveDate": {
+          "example": "2024-03-20",
+          "type": "string",
+          "format": "date",
+          "description": "the date at which the regulation came into effect."
+        }
+      },
+      "description": "A regulation (eg EU deforestation regulation) that defines the criteria for assessment.",
+      "required": ["administeredBy"]
+    },
+    "Criterion": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "default": "Criterion",
+          "enum": ["Criterion"]
+        },
+        "id": {
+          "example": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the criteria within the standard  or regulation. For example CO2 emissions calaculations for liquid fule combusion."
+        },
+        "name": {
+          "example": "GBA Battery rule book v2.0 battery assembly guidelines.",
+          "type": "string",
+          "description": "A name that describes this criteria."
+        },
+        "thresholdValues": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "A conformity threshold defined by the specification (eg minimum compressive strength) "
+        }
+      },
+      "description": "A specific rule or criterion within a standard or regulation. eg a carbon intensity calculation rule within an emissions standard.",
+      "required": ["id", "name"]
+    },
+    "Metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "metricName": {
+          "example": "GHG emissions intensity",
+          "type": "string",
+          "description": "A human readable name for this metric (for example \"Tensile strength\")"
+        },
+        "metricValue": {
+          "$ref": "#/$defs/Measure",
+          "description": "A numeric value and unit of measure for this metric. Could be a measured value or a specified threshold. Eg {\"value\":400, \"unit\":\"MPA\"} as tensile strenght of structural steel"
+        },
+        "accuracy": {
+          "example": 0.05,
+          "type": "number",
+          "description": "A percentage represented as a numeric between 0 and 1 indicating the rage of accuracy of the claimed value (eg 0.05 means that the actual value is within 5% of the claimed value.)"
+        }
+      },
+      "description": "A specific measure of performance against the criteria that governs the claim.  Expressed as an array of metric (ie unit of emasure) / value (ie the actual numeric value) pairs.  ",
+      "required": ["metricName", "metricValue"]
+    }
+  }
+}

--- a/website/static/schema/aatp-dlp-schema-0.4.0.json
+++ b/website/static/schema/aatp-dlp-schema-0.4.0.json
@@ -1,0 +1,1058 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "array",
+      "readOnly": true,
+      "const": ["DigitalLivestockPassport", "VerifiableCredential"],
+      "default": ["DigitalLivestockPassport", "VerifiableCredential"],
+      "items": {
+        "type": "string",
+        "enum": ["DigitalLivestockPassport", "VerifiableCredential"]
+      }
+    },
+    "@context": {
+      "example": "https://test.uncefact.org/vocabulary/untp/dpp/dpp-context.jsonld",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://vocabulary.aatp.org/aatp/dlp0.4.0"
+        ]
+      },
+      "description": "A list of JSON-LD context URIs that define the semantic meaning of properties within the credential. ",
+      "readOnly": true,
+      "const": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://vocabulary.aatp.org/aatp/dlp0.4.0"
+      ],
+      "default": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://vocabulary.aatp.org/aatp/dlp0.4.0"
+      ]
+    },
+    "id": {
+      "example": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
+      "type": "string",
+      "format": "uri",
+      "description": "A unique identifier (URI) assigned to the product passport. May be a UUID"
+    },
+    "issuer": {
+      "$ref": "#/$defs/CredentialIssuer",
+      "description": "The organisation that is the issuer of this VC. Note that the \"id\" property MUST be a W3C DID.  Other identifiers such as tax registration numbers can be listed in the \"otherIdentifiers\" property."
+    },
+    "validFrom": {
+      "example": "2024-03-15T12:00:00",
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time from which the credential is valid."
+    },
+    "validUntil": {
+      "example": "2034-03-15T12:00:00",
+      "type": "string",
+      "format": "date-time",
+      "description": "The expiry date (if applicable) of this verifiable credential."
+    },
+    "credentialSubject": {
+      "$ref": "#/$defs/BovineAnimal",
+      "description": "The animal record that is the subject of this digital livestock passport. "
+    }
+  },
+  "description": "A digital livestock passport (Cattle) as a verifiable credential. ",
+  "required": ["@context", "id", "issuer"],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "CredentialIssuer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["CredentialIssuer"],
+          "default": ["CredentialIssuer"],
+          "items": {
+            "type": "string",
+            "enum": ["CredentialIssuer"]
+          }
+        },
+        "id": {
+          "example": "did:web:identifiers.example-company.com:12345",
+          "type": "string",
+          "format": "uri",
+          "description": "The W3C DID of the issuer - should be a did:web or did:tdw"
+        },
+        "name": {
+          "example": "Example Company Pty Ltd",
+          "type": "string",
+          "description": "The name of the issuer person or organisation"
+        },
+        "otherIdentifier": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Identifier"
+          },
+          "description": "An optional list of other registered identifiers for this credential issuer "
+        }
+      },
+      "description": "The issuer party (person or organisation) of a verifiable credential.",
+      "required": ["id", "name"]
+    },
+    "Identifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Identifier"],
+          "default": ["Identifier"],
+          "items": {
+            "type": "string",
+            "enum": ["Identifier"]
+          }
+        },
+        "id": {
+          "example": "https://id.gs1.org/01/09520123456788/21/12345",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique ID of the entity as a resolvable URL according to ISO 18975. ExamplesProduct - id.gs1.org/01/09520123456788/21/12345  Party - abr.business.gov.au/ABN/View?abn=90664869327. Facility - did:web:facilities.example-company.com:123. "
+        },
+        "name": {
+          "example": "EV battery 300Ah.",
+          "type": "string",
+          "description": "The registered name of the entity within the identifier scheme.  Examples: product - EV battery 300Ah, Party - Sample Company Pty Ltd,  Facility - Green Acres battery factory"
+        },
+        "registeredId": {
+          "example": "90664869327",
+          "type": "string",
+          "description": "The registration number (alphanumeric) of the entity within the register. Unique within the register."
+        },
+        "idScheme": {
+          "$ref": "#/$defs/IdentifierScheme",
+          "description": "The identifier scheme.  Examples : Product - id.gs1.org/01,  Party - business.gov.au/abn,  Facility - did:web:facilities.acme.com. "
+        }
+      },
+      "description": "The ID and Name of an identified entity such as a product, facility, party, standard, etc.  If the identifier is a W3C DID then the corresponding DID document SHOULD include a serviceEndpoint of type \"IdentityResolver\". If the identifier is not a W3C DID then the id property SHOULD be an identity resolver URL.",
+      "required": ["id", "name"]
+    },
+    "IdentifierScheme": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["IdentifierScheme"],
+          "default": ["IdentifierScheme"],
+          "items": {
+            "type": "string",
+            "enum": ["IdentifierScheme"]
+          }
+        },
+        "id": {
+          "example": "https://id.gs1.org/01/",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique identifier of the registration scheme. The scheme should be registered and discoverable from vocabulary.uncefact.org/identifierSchemes"
+        },
+        "name": {
+          "example": "Global Trade Identification Number (GTIN)",
+          "type": "string",
+          "description": "The name of the identifier scheme. "
+        }
+      },
+      "description": "An identifier registration scheme for products, facilities, or organisations. Typically operated by a state, national or global authority."
+    },
+    "BovineAnimal": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["BovineAnimal", "Product"],
+          "default": ["BovineAnimal", "Product"],
+          "items": {
+            "type": "string",
+            "enum": ["BovineAnimal", "Product"]
+          }
+        },
+        "countryOfProduction": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId",
+          "description": "The country in which this item was produced / manufactured.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId\n    "
+        },
+        "id": {
+          "example": "https://nlis.com.au/QDBH0132XBS01234",
+          "type": "string",
+          "format": "uri",
+          "description": "The NLIS ID of the animal as a full resolvable URI"
+        },
+        "name": {
+          "example": "Angus, grass fed, 2024",
+          "type": "string",
+          "description": "The registered name of the product within the identifier scheme. "
+        },
+        "registeredId": {
+          "example": "QDBH0132XBS01234",
+          "type": "string",
+          "description": "The NLIS ID of the Animal"
+        },
+        "idScheme": {
+          "$ref": "#/$defs/IdentifierScheme",
+          "description": "The identifier scheme for this product.  Eg a GS1 GTIN or an AU Livestock NLIS, or similar. If self issued then use the party ID of the issuer.  "
+        },
+        "batchNumber": {
+          "example": "Mob-2024-12",
+          "type": "string",
+          "description": "Identifier of the specific production batch of the product.  Unique within the product class."
+        },
+        "productImage": {
+          "$ref": "#/$defs/Link",
+          "description": "Reference information (location, type, name) of an image of the product."
+        },
+        "description": {
+          "example": "Fresh from the family farm at the foothills of the Snowy Mountains. All cattle are single-origin, grass-fed, antibiotic and hormone-free.",
+          "type": "string",
+          "description": "A textual description providing details about the product."
+        },
+        "productCategory": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": "A code representing the product's class, typically using the UN CPC (United Nations Central Product Classification) https://unstats.un.org/unsd/classifications/Econ/cpc"
+        },
+        "furtherInformation": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Link"
+          },
+          "description": "A URL pointing to further human readable information about the product."
+        },
+        "producedByParty": {
+          "$ref": "#/$defs/Identifier",
+          "description": "The business name and ABN that owns the farm that is the producer (birth) of the animal."
+        },
+        "producedAtFacility": {
+          "$ref": "#/$defs/Identifier",
+          "description": "The farm name and identifier (usually a PIC - Property Identification Code) of the farm that produced the animal."
+        },
+        "productionDate": {
+          "example": "2024-04-25",
+          "type": "string",
+          "format": "date",
+          "description": "The birth date of the animal."
+        },
+        "granularityLevel": {
+          "type": "string",
+          "enum": ["item", "batch", "model"],
+          "example": "item",
+          "description": "Code to indicate the granularity of this digital product passport - item level, batch level or product class level."
+        },
+        "conformityClaim": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Claim"
+          },
+          "description": "An array of claim objects representing various product conformity claims about the product / batch.  These can be sustainability claims, circularity claims, or any other claim type within the conformity topic list."
+        },
+        "emissionsScorecard": {
+          "$ref": "#/$defs/EmissionsPerformance",
+          "description": "The emissions scorecard for this animal in accordance witht he GHG protocol"
+        },
+        "traceabilityInformation": {
+          "$ref": "#/$defs/TraceabilityPerformance",
+          "description": "An array of traceability events grouped by value chain process.  Where actual traceability events are unavailable or carry sensitive information, passport publishers may specify the extent to which the traceability information has been independently verified. "
+        },
+        "characteristics": {
+          "$ref": "#/$defs/BovineCharcteristics",
+          "description": "Bovine characteristcs at the date of livestock passport issue - terminology from MLA National Livestiock Guidelines 2022 - https://www.ausmeat.com.au/media/1521/mla-national-livestock-guidelines-2022-web_final_291122.pdf.  "
+        },
+        "healthTreatment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HealthTreatment"
+          },
+          "description": "A list of animal health treatment records. "
+        }
+      },
+      "description": "A bovine animal record - including ",
+      "required": ["id", "name"]
+    },
+    "Link": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Link"],
+          "default": ["Link"],
+          "items": {
+            "type": "string",
+            "enum": ["Link"]
+          }
+        },
+        "linkURL": {
+          "example": "https://files.example-certifier.com/1234567.json",
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the target resource. "
+        },
+        "linkName": {
+          "example": "GBA rule book conformity certificate",
+          "type": "string",
+          "description": "A display name for the target resource "
+        },
+        "linkType": {
+          "example": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
+          "type": "string",
+          "description": "The type of the target resource - drawn from a controlled vocabulary "
+        }
+      },
+      "description": "A structure to provide a URL link plus metadata associated with the link."
+    },
+    "Classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Classification"],
+          "default": ["Classification"],
+          "items": {
+            "type": "string",
+            "enum": ["Classification"]
+          }
+        },
+        "id": {
+          "example": "https://unstats.un.org/unsd/classifications/Econ/cpc/46410",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique URI representing the specific classifier value"
+        },
+        "code": {
+          "example": "46410",
+          "type": "string",
+          "description": "classification code within the scheme"
+        },
+        "name": {
+          "example": "Primary cells and primary batteries",
+          "type": "string",
+          "description": "Name of the classification represented by the code"
+        },
+        "schemeID": {
+          "example": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+          "type": "string",
+          "format": "uri",
+          "description": "Classification scheme ID"
+        },
+        "schemeName": {
+          "example": "UN Central Product Classification (CPC)",
+          "type": "string",
+          "description": "The name of the classification scheme"
+        }
+      },
+      "description": "A classification scheme and code / name representing a category value for a product, entity, or facility.",
+      "required": ["id", "name"]
+    },
+    "Claim": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Claim", "Declaration"],
+          "default": ["Claim", "Declaration"],
+          "items": {
+            "type": "string",
+            "enum": ["Claim", "Declaration"]
+          }
+        },
+        "assessmentDate": {
+          "example": "2024-03-15",
+          "type": "string",
+          "format": "date",
+          "description": "The date on which this assessment was made. "
+        },
+        "declaredValue": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "The list of specific values measured as part of this assessment (eg tensile strength)"
+        },
+        "id": {
+          "example": "https://products.example-company.com/09520123456788/declarations/12345",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the declaration. Often this will be an extension of the product.id or attestation.id. But could be a UUID."
+        },
+        "referenceStandard": {
+          "$ref": "#/$defs/Standard",
+          "description": "The reference to the standard that defines the specification / criteria"
+        },
+        "referenceRegulation": {
+          "$ref": "#/$defs/Regulation",
+          "description": "The reference to the regulation that defines the assessment criteria"
+        },
+        "assessmentCriteria": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Criterion"
+          },
+          "description": "The specification against which the assessment is made."
+        },
+        "declaredValues": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "The list of specific values measured as part of this assessment (eg tensile strength)"
+        },
+        "conformance": {
+          "example": "true",
+          "type": "boolean",
+          "description": "An indicator of whether or not the claim or assesment conforms to the regulatory or standard criteria."
+        },
+        "conformityTopic": {
+          "type": "string",
+          "enum": [
+            "environment.energy",
+            "environment.emissions",
+            "environment.water",
+            "environment.waste",
+            "environment.deforestation",
+            "environment.biodiversity",
+            "circularity.content",
+            "circularity.design",
+            "social.labour",
+            "social.rights",
+            "social.community",
+            "social.safety",
+            "governance.ethics",
+            "governance.compliance",
+            "governance.transparency"
+          ],
+          "example": "environment.energy",
+          "description": "The conformity topic category for this assessment (eg vocabulary.uncefact.org/sustainability/emissions)"
+        },
+        "conformityEvidence": {
+          "$ref": "#/$defs/SecureLink",
+          "description": "A URI pointing to the evidence supporting the claim. SHOULD be a URL to a UNTP Digital Conformity Credential (DCC)"
+        }
+      },
+      "description": "A declaration of conformance with one or more criteria from a specific standard or regulation.  ",
+      "required": ["id", "conformance", "conformityTopic"]
+    },
+    "Metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Metric"],
+          "default": ["Metric"],
+          "items": {
+            "type": "string",
+            "enum": ["Metric"]
+          }
+        },
+        "metricName": {
+          "example": "GHG emissions intensity",
+          "type": "string",
+          "description": "A human readable name for this metric (for example \"Tensile strength\")"
+        },
+        "metricValue": {
+          "$ref": "#/$defs/Measure",
+          "description": "A numeric value and unit of measure for this metric. Could be a measured value or a specified threshold. Eg {\"value\":400, \"unit\":\"MPA\"} as tensile strength of structural steel"
+        },
+        "score": {
+          "example": "BB",
+          "type": "string",
+          "description": "A score or rank associated with this measured metric."
+        },
+        "accuracy": {
+          "example": 0.05,
+          "type": "number",
+          "description": "A percentage represented as a numeric between 0 and 1 indicating the rage of accuracy of the claimed value (eg 0.05 means that the actual value is within 5% of the claimed value.)"
+        }
+      },
+      "description": "A specific measure of performance against the criteria that governs the claim.  Expressed as an array of metric (ie unit of measure) / value (ie the actual numeric value) pairs.  ",
+      "required": ["metricName", "metricValue"]
+    },
+    "Measure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Measure"],
+          "default": ["Measure"],
+          "items": {
+            "type": "string",
+            "enum": ["Measure"]
+          }
+        },
+        "value": {
+          "example": 10,
+          "type": "number",
+          "description": "The numeric value of the measure"
+        },
+        "unit": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/UnitMeasureCode",
+          "description": "Unit of measure drawn from the UNECE Rec20 measure code list.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/UnitMeasureCode\n    "
+        }
+      },
+      "description": "The measure class defines a numeric measured value (eg 10) and a coded unit of measure (eg KG).",
+      "required": ["value", "unit"]
+    },
+    "Standard": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Standard"],
+          "default": ["Standard"],
+          "items": {
+            "type": "string",
+            "enum": ["Standard"]
+          }
+        },
+        "id": {
+          "example": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the standard (eg https://www.iso.org/standard/60857.html)."
+        },
+        "name": {
+          "example": "GBA Battery Passport Greenhouse Gas Rulebook - V.2.0",
+          "type": "string",
+          "description": "The name of the standard"
+        },
+        "issuingParty": {
+          "$ref": "#/$defs/Identifier",
+          "description": "The party that issued the standard "
+        },
+        "issueDate": {
+          "example": "2023-12-05",
+          "type": "string",
+          "format": "date",
+          "description": "The date when the standard was issued."
+        }
+      },
+      "description": "A standard (eg ISO 14000) that specifies the criteria for conformance.",
+      "required": ["issuingParty"]
+    },
+    "Regulation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Regulation"],
+          "default": ["Regulation"],
+          "items": {
+            "type": "string",
+            "enum": ["Regulation"]
+          }
+        },
+        "id": {
+          "example": "https://www.legislation.gov.au/F2008L02309/latest/versions",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique identifier of this regulation. "
+        },
+        "name": {
+          "example": "NNational Greenhouse and Energy Reporting (Measurement) Determination",
+          "type": "string",
+          "description": "The name of the regulation or act."
+        },
+        "jurisdictionCountry": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId",
+          "description": "The legal jurisdiction (country) under which the regulation is issued.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId\n    "
+        },
+        "administeredBy": {
+          "$ref": "#/$defs/Identifier",
+          "description": "the issuing body of the regulation. For example Australian Government Department of Climate Change, Energy, the Environment and Water"
+        },
+        "effectiveDate": {
+          "example": "2024-03-20",
+          "type": "string",
+          "format": "date",
+          "description": "the date at which the regulation came into effect."
+        }
+      },
+      "description": "A regulation (eg EU deforestation regulation) that defines the criteria for assessment.",
+      "required": ["administeredBy"]
+    },
+    "Criterion": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["Criterion"],
+          "default": ["Criterion"],
+          "items": {
+            "type": "string",
+            "enum": ["Criterion"]
+          }
+        },
+        "id": {
+          "example": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the criterion within the standard  or regulation. For example CO2 emissions calculations for liquid fuel combustion."
+        },
+        "name": {
+          "example": "GBA Battery rule book v2.0 battery assembly guidelines.",
+          "type": "string",
+          "description": "A name that describes this criteria."
+        },
+        "thresholdValues": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "A conformity threshold defined by the specification (eg minimum compressive strength) "
+        }
+      },
+      "description": "A specific rule or criterion within a standard or regulation. eg a carbon intensity calculation rule within an emissions standard.",
+      "required": ["id", "name"]
+    },
+    "SecureLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["SecureLink", "Link"],
+          "default": ["SecureLink", "Link"],
+          "items": {
+            "type": "string",
+            "enum": ["SecureLink", "Link"]
+          }
+        },
+        "linkURL": {
+          "example": "https://files.example-certifier.com/1234567.json",
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the target resource. "
+        },
+        "linkName": {
+          "example": "GBA rule book conformity certificate",
+          "type": "string",
+          "description": "A display name for the target resource "
+        },
+        "linkType": {
+          "example": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
+          "type": "string",
+          "description": "The type of the target resource - drawn from a controlled vocabulary "
+        },
+        "hashDigest": {
+          "example": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+          "type": "string",
+          "description": "The hash of the file."
+        },
+        "hashMethod": {
+          "type": "string",
+          "enum": ["SHA-256", "SHA-1"],
+          "example": "SHA-256",
+          "description": "The hashing algorithm used to create the target hash.  SHA-265 is the recommended standard"
+        },
+        "encryptionMethod": {
+          "type": "string",
+          "enum": ["none", "AES"],
+          "example": "none",
+          "description": "The symmetric encryption algorithm used to encrypt the link target.  AES is the recommended standard. Decryption keys are expected to be passed out of bounds."
+        }
+      },
+      "description": "A binary file that is hashed ()for tamper evidence) and optionally encrypted (for confidentiality)."
+    },
+    "EmissionsPerformance": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["EmissionsPerformance"],
+          "default": ["EmissionsPerformance"],
+          "items": {
+            "type": "string",
+            "enum": ["EmissionsPerformance"]
+          }
+        },
+        "carbonFootprint": {
+          "example": 1.8,
+          "type": "number",
+          "format": "float",
+          "description": "The carbon footprint of the product in KgCO2e per declared unit."
+        },
+        "declaredUnit": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/UnitMeasureCode",
+          "description": "The unit of product (EA, KGM, LTR, etc) that is the basis for carbon footprint.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/UnitMeasureCode\n    "
+        },
+        "operationalScope": {
+          "type": "string",
+          "enum": ["None", "CradleToGate", "CradleToGrave"],
+          "example": "None",
+          "description": "The operational scope of the emissions performance. Only scope 1 & 2, or including upstream scope 3 (cradle to gate) or upstream and downstream scope 3 (cradle to grave)."
+        },
+        "primarySourcedRatio": {
+          "example": 0.3,
+          "type": "number",
+          "format": "float",
+          "description": "The ratio of emissions data from primary sources (ie from supplier / product specific information rather than secondary / industry averages)."
+        },
+        "reportingStandard": {
+          "$ref": "#/$defs/Standard",
+          "description": "The reporting standard (eg GHG Protocol, IFRS S2, ESRS, etc) against which this product emissions performance is assessed."
+        }
+      },
+      "description": "Product specific characteristics.  This class is an extension point for industry specific product characteristics or performance information such as clothing size or battery capacity.",
+      "required": [
+        "carbonFootprint",
+        "declaredUnit",
+        "operationalScope",
+        "primarySourcedRatio"
+      ]
+    },
+    "TraceabilityPerformance": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["TraceabilityPerformance"],
+          "default": ["TraceabilityPerformance"],
+          "items": {
+            "type": "string",
+            "enum": ["TraceabilityPerformance"]
+          }
+        },
+        "valueChainProcess": {
+          "example": "Spinning",
+          "type": "string",
+          "description": "Human readable name for the industry specific value chain process representing this traceability data set."
+        },
+        "verifiedRatio": {
+          "example": 0.5,
+          "type": "number",
+          "description": "The proportion (0 to 1) of materials in this value chain process that have been  traced using verifiable traceability event."
+        },
+        "traceabilityEvent": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SecureLink"
+          },
+          "description": "A list of secure links to digital traceability events that support this traceability performance statement. May be encrypted for confidentiality purposes. "
+        }
+      },
+      "description": "An array of secure links to TraceabilityEvent objects detailing EPCIS events related to the traceability of the product batch. Events are grouped by value chain process (eg \"Weaving\" in textiles supply chain)."
+    },
+    "BovineCharcteristics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["BovineCharcteristics"],
+          "default": ["BovineCharcteristics"],
+          "items": {
+            "type": "string",
+            "enum": ["BovineCharcteristics"]
+          }
+        },
+        "sex": {
+          "type": "string",
+          "enum": ["M", "F"],
+          "example": "M",
+          "description": "The sex of the animal."
+        },
+        "sexCharacteristic": {
+          "type": "string",
+          "enum": [
+            "HY",
+            "C",
+            "CSP",
+            "HC",
+            "H",
+            "HSP",
+            "BY",
+            "SC",
+            "S",
+            "V",
+            "MFV",
+            "BC",
+            "B",
+            "SY",
+            "RV"
+          ],
+          "example": "HY",
+          "description": "Characteristic based on sex and age. Eg HY for yearling heiffer"
+        },
+        "breed": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AA",
+              "AB",
+              "AF",
+              "AK",
+              "AL",
+              "AN",
+              "AU",
+              "AY",
+              "BA",
+              "BB",
+              "BC",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BJ",
+              "BK",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CB",
+              "CC",
+              "CD",
+              "CF",
+              "CI",
+              "CN",
+              "DD",
+              "DK",
+              "DM",
+              "DR",
+              "DS",
+              "DX",
+              "FF",
+              "FS",
+              "GA",
+              "GC",
+              "GG",
+              "GM",
+              "GV",
+              "HH",
+              "HI",
+              "HU",
+              "HV",
+              "IB",
+              "IS",
+              "JJ",
+              "KA",
+              "KW",
+              "LB",
+              "LH",
+              "LL",
+              "LR",
+              "LU",
+              "MA",
+              "MD",
+              "MG",
+              "MH",
+              "MI",
+              "MO",
+              "MS",
+              "MU",
+              "MZ",
+              "NG",
+              "NL",
+              "NO",
+              "OO",
+              "OZ",
+              "PH",
+              "PM",
+              "PR",
+              "PT",
+              "PU",
+              "PZ",
+              "QL",
+              "RA",
+              "RB",
+              "RC",
+              "RF",
+              "RO",
+              "RP",
+              "RS",
+              "RV",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SG",
+              "SH",
+              "SI",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SP",
+              "SQ",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SW",
+              "TA",
+              "TC",
+              "TH",
+              "TI",
+              "TN",
+              "TP",
+              "TS",
+              "TX",
+              "UR",
+              "UU",
+              "WA",
+              "WB",
+              "WY",
+              "XA",
+              "XD",
+              "XH",
+              "XK",
+              "XM",
+              "XR",
+              "XS",
+              "XT",
+              "XX",
+              "XY",
+              "ZE"
+            ]
+          },
+          "example": "AA",
+          "description": "Breed code array.  Single code for pure bred cattle. List each breed for mixed breeds. eg [\"AA\"] represewnts pure bred Angus."
+        },
+        "liveWeight": {
+          "example": 350,
+          "type": "number",
+          "format": "float",
+          "description": "Live weight of the animal in Kg"
+        },
+        "carcassWeight": {
+          "example": 180,
+          "type": "number",
+          "format": "float",
+          "description": "Carcass weight in Kg - only applicable if passport is issued post slaughter."
+        },
+        "fatScore": {
+          "type": "string",
+          "enum": ["1", "2", "3", "4", "5", "6"],
+          "example": "1",
+          "description": "Fat score based on depth of fat at 12th to 13th rib. 1 is lightest and 6 is heaviest. "
+        },
+        "muscleScore": {
+          "type": "string",
+          "enum": ["A", "B", "C", "D", "E"],
+          "example": "A",
+          "description": "Muscle score based on thickness through stifle. A is heaviest, E is lightest."
+        },
+        "frameSize": {
+          "type": "string",
+          "enum": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
+          "example": "1",
+          "description": "Frame size (lookup based on hook height for given age and sex). 1 is the smallest and 11 is the largest."
+        },
+        "maturity": {
+          "type": "string",
+          "enum": ["early", "moderate", "late", "veryLate"],
+          "example": "early",
+          "description": "Maturity type or growth potential is a way of describingthe skeletal size of cattle. Frame score, which is the height of a beef animal at a given age can be used as a measure of its maturity type. Given adequate nutrition and health, most animals should maintain the same frame score and hence maturity type throughout their life, while actual height increases with age."
+        }
+      },
+      "description": "Bovine characteristcs at the date of livestock passport issue - terminology from MLA National Livestiock Guidelines 2022 - https://www.ausmeat.com.au/media/1521/mla-national-livestock-guidelines-2022-web_final_291122.pdf.  "
+    },
+    "HealthTreatment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": ["HealthTreatment"],
+          "default": ["HealthTreatment"],
+          "items": {
+            "type": "string",
+            "enum": ["HealthTreatment"]
+          }
+        },
+        "icarDiseaseCategory": {
+          "type": "string",
+          "enum": ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+          "example": "1",
+          "description": "The disease category that this treatment targets."
+        },
+        "treatmentDate": {
+          "example": "2024-07-24",
+          "type": "string",
+          "format": "date",
+          "description": "The data the treatment was applied."
+        },
+        "productId": {
+          "type": "string",
+          "x-external-enumeration": "https://portal.apvma.gov.au/pubcris",
+          "description": "The APVMA product code for the treatment ideally as a resolvable URL\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://portal.apvma.gov.au/pubcris\n    "
+        },
+        "productBatchId": {
+          "example": "https://id.yourbrand.com/01/09312345678907/10/ABC123/21/456789A",
+          "type": "string",
+          "description": "The batch number of the specific treatment product."
+        },
+        "productExpiry": {
+          "example": "2025-04-20",
+          "type": "string",
+          "format": "date",
+          "description": "The expiry date of the specific treatemtn product batch."
+        },
+        "productName": {
+          "example": "PENEZIN ANTIBIOTIC INJECTION",
+          "type": "string",
+          "description": "The name of the treatment product"
+        },
+        "doseRate": {
+          "$ref": "#/$defs/Measure",
+          "description": "The dose rate for the administered treatment."
+        },
+        "witholdingPeriod": {
+          "example": 5,
+          "type": "integer",
+          "description": "The pre-slauhghter / pre export witholding period in days for this treatment.  "
+        }
+      },
+      "description": "An animal health treatment record."
+    }
+  }
+}


### PR DESCRIPTION
This PR duplicates the aatp schemas and context files in the static directory, exposing these assets without the appended hash.

I've kept the original assets within the schema folder to avoid introducing a breaking change.

Current asset URIs:
- https://aatp.foodagility.com/assets/files/aatp-dlp-context-0.4.0-7ed6f0cf85aa7626c480bd85212de2e4.jsonld
- https://aatp.foodagility.com/assets/files/aatp-dlp-schema-0.4.0-9c0ad2b1ca6a9e497dedcfd8b87f35f1.json

New asset URIs:
- https://aatp.foodagility.com/context/aatp-dlp-context-0.4.0.jsonld
- https://aatp.foodagility.com/schema/aatp-dlp-schema-0.4.0.json